### PR TITLE
Better zeus detection

### DIFF
--- a/plugin/spec-runner.vim
+++ b/plugin/spec-runner.vim
@@ -89,7 +89,7 @@ function! s:InJavascriptFile()
 endfunction
 
 function! s:Preloader()
-  if filereadable('zeus.json') || s:FileInProjectRoot('zeus.json')
+  if filereadable('zeus.json') || s:FileInProjectRoot('zeus.json') || filereadable('.zeus.sock') || s:FileInProjectRoot('.zeus.sock')
     return 'zeus'
   elseif s:InRspecFile() && s:InGemfile('spring-commands-rspec')
     return 'spring'

--- a/spec/plugin/spec_runner_spec.rb
+++ b/spec/plugin/spec_runner_spec.rb
@@ -246,6 +246,14 @@ describe 'Vim Spec Runner' do
       expect(command).to start_with 'zeus'
     end
 
+    it 'uses "zeus" when a .zeus.sock file is present' do
+      set_up_zeus(using_socket: true)
+
+      run_spec_file
+
+      expect(command).to start_with 'zeus'
+    end
+
     it 'is "zeus" even when Vim is not in the same directory as zeus.json' do
       subdirectory = 'sub/directory'
       set_up_zeus
@@ -361,8 +369,8 @@ describe 'Vim Spec Runner' do
     previous_command
   end
 
-  def set_up_zeus
-    create_file_in_root 'zeus.json'
+  def set_up_zeus using_socket: false
+    using_socket ? create_file_in_root('.zeus.sock') : create_file_in_root('zeus.json')
   end
 
   def set_up_spring_for(runner)


### PR DESCRIPTION
The only way zeus is detected is if there is a `zeus.json` file in the project. However some projects do not use this file. zeus creates a `.zeus.sock` file when it is running to prevent multiple instances of itself being run on the same project.

This change looks for the `.zeus.sock` file along with a `zeus.json` file.