### PR TITLE
Modularity: users can customize runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It can run RSpec files or JavaScript files (with [Teaspoon]).
 Benefits
 --------
 
+* Customizable spec commands: if the plugin doesn't know about a spec type,
+  you can write your own adapter with a single function
 * Has commands to run a single test case, run a whole spec file, or re-run the
   last spec command
 * If you're editing a non-spec file and you run `vim-spec-runner`, it
@@ -22,7 +24,6 @@ Benefits
   [vim-tmux-runner] or [tslime]
 * Automatically detects and uses preloaders ([zeus] and [spring])
 * Saves the current file before running specs
-* Customizable spec commands
 
 [zeus]: https://github.com/burke/zeus
 [spring]: https://github.com/rails/spring

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ there. For example, if you want to run `cool_rspec` for rspec files, but use
 
 ```vim
 let g:spec_runner_available_runners['rspec'] = {
-      \ 'rspec : { 'no_preloader': cool_rspec 'spring 'spring_cool_rspec' }
+      \ 'rspec': { 'no_preloader': 'cool_rspec', 'spring': 'spring_cool_rspec' }
       \ }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Benefits
   [vim-tmux-runner] or [tslime]
 * Automatically detects and uses preloaders ([zeus] and [spring])
 * Saves the current file before running specs
+* Customizable spec commands
 
 [zeus]: https://github.com/burke/zeus
 [spring]: https://github.com/rails/spring
@@ -77,6 +78,8 @@ Reasons, even though you're typing `map`, it's a normal-mode mapping.
 Configuration
 -------------
 
+### `g:spec_runner_dispatcher`
+
 The `g:spec_runner_dispatcher` variable is used by all three public commands to
 run specs. By default, it echoes the command and then runs it:
 
@@ -107,6 +110,47 @@ that:
 ```vim
 let g:disable_write_on_spec_run = 1
 ```
+
+### `g:spec_runner_available_runners`
+
+This variable tells the plugin what command to run based on the type of test
+it's running. Here's the default:
+
+```vim
+let g:spec_runner_available_runners = {
+      \ 'rspec' : 'rspec',
+      \ 'teaspoon' : { 'no_preloader': 'teaspoon', 'zeus': 'rake teaspoon' },
+      \ }
+```
+
+That means that if the file is detected as an `rspec` file, run `rspec`. If the
+file is detected as a `teaspoon` file, use `rake teaspoon` if using zeus as a
+preloader, otherwise use `teaspoon`. You can add your own or change what's
+there. For example, if you want to run `cool_rspec` for rspec files, but use
+`spring_cool_rspec` when also using spring as a preloader:
+
+```vim
+let g:spec_runner_available_runners['rspec'] = {
+      \ 'rspec : { 'no_preloader': cool_rspec 'spring 'spring_cool_rspec' }
+      \ }
+```
+
+### Detecting custom filetypes
+
+To run a custom file, first tell `vim-spec-runner` how to run files of that
+type using the `g:spec_runner_available_runners` variable described above. Let's
+say you define a type called `blorg`, so there's an entry in
+`g:spec_runner_available_runners` with a key of `blorg`. Now define a function
+that can detect `blorg` files:
+
+```vim
+function! g:SpecRunner_detect_blorg()
+  " Return true if the file ends in '.blorg'
+  return match(@%, '.blorg$') != -1
+endfunction
+```
+
+That's it - now `vim-spec-runner` knows how to detect and run `blorg` files.
 
 Running the plugin's tests
 --------------------------

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ that:
 let g:disable_write_on_spec_run = 1
 ```
 
-### `g:spec_runner_available_runners`
+### Custom commands for different spec types
 
-This variable tells the plugin what command to run based on the type of test
-it's running. Here's the default:
+The `g:spec_runner_available_runners` variable tells the plugin what command to
+run based on the type of test it's running. Here's the default:
 
 ```vim
 let g:spec_runner_available_runners = {

--- a/plugin/spec-runner.vim
+++ b/plugin/spec-runner.vim
@@ -101,7 +101,7 @@ function! s:Runner()
     if type(runner) == type('')
       return runner
     " Otherwise the runner might be
-    " { 'no_preloader': 'teaspoon', 'zeus': 'rake " teaspoon' },
+    " { 'no_preloader': 'teaspoon', 'zeus': 'rake teaspoon' },
     " so we need to determine if we should use the preloader version
     " or the normal version.
     elseif type(runner) == type({})

--- a/spec/plugin/spec_runner_spec.rb
+++ b/spec/plugin/spec_runner_spec.rb
@@ -299,6 +299,23 @@ describe 'Vim Spec Runner' do
     end
   end
 
+  context 'with a custom command' do
+    it 'correctly detects the file and runs the write command' do
+      spec_file = 'my_spec.blorg'
+      vim.command "let g:spec_runner_available_runners['blorg'] = 'blorg'"
+      vim.command <<-EOFUNCTION
+        function! g:SpecRunner_detect_blorg()
+          return match(@%, '.blorg$') != -1
+        endfunction
+      EOFUNCTION
+
+      vim.edit 'my_spec.blorg'
+      vim.command 'RunCurrentSpecFile'
+
+      expect(command).to eq 'blorg my_spec.blorg'
+    end
+  end
+
   def run_spec_file(spec_file = 'my_spec.rb', vim_instance = vim)
     vim_instance.edit spec_file
     vim_instance.command 'RunCurrentSpecFile'


### PR DESCRIPTION
Users can customize existing runners or add new runners for filetypes we haven't written yet.

The `g:spec_runner_available_runners` variable maps runner names to runner commands. Runner names are arbitrary and only matter in that they must match up to detection functions like `g:SpecRunner_detect_rspec`.

This isn't fully modular yet, though it is a good start. For example, the `s:Path` function should be factored out as part of the teaspoon plugin, though I'm not quite sure how yet:

``` vim
function! s:Path()
  if s:Runner() ==# 'rake teaspoon'
    return ' files=' . @%
  else
    return @%
  end
endfunction
```
