### PR TITLE
Allow preloader to be overridden

### DIFF
--- a/plugin/spec-runner.vim
+++ b/plugin/spec-runner.vim
@@ -89,6 +89,10 @@ function! s:InJavascriptFile()
 endfunction
 
 function! s:Preloader()
+  if exists('g:spec_runner_preloader')
+    return g:spec_runner_preloader
+  endif
+
   if filereadable('zeus.json') || s:FileInProjectRoot('zeus.json') || filereadable('.zeus.sock') || s:FileInProjectRoot('.zeus.sock')
     return 'zeus'
   elseif s:InRspecFile() && s:InGemfile('spring-commands-rspec')


### PR DESCRIPTION
If `./bin` isn't on the load path, then the preloader needs to call `bin/spring` rather than just `spring`.

I wasn't able to the test suite to run, so apologies for the lack of a test.