### PR TITLE
Update instructions for running the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ let g:spec_runner_preloader = ''
 Running the plugin's tests
 --------------------------
 
-    rake
+    bundle exec rake
 
 If you get errors on OSX about `Vimrunner`, try installing MacVim then re-running the specs:
 


### PR DESCRIPTION
Using `bundle exec` should ensure the correct gem versions are used,
rather than whatever happens to be installed on the system.
